### PR TITLE
Remove `crypto` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/expect.js": "^0.3.29",
     "@types/mocha": "^5.2.7",
     "@types/nock": "^10.0.3",
+    "@types/node": "^6.9.0",
     "@types/superagent": "^4.1.3",
     "expect.js": "^0.3.1",
     "markdownlint": "^0.15.0",
@@ -33,7 +34,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "crypto": "^1.0.1",
     "superagent": "^5.1.0"
   },
   "directories": {
@@ -52,5 +52,8 @@
     "url": "https://github.com/NodePit/node-mailchimp/issues"
   },
   "homepage": "https://github.com/NodePit/node-mailchimp",
-  "description": "Node.js client for managing Mailchimp subscriptions"
+  "description": "Node.js client for managing Mailchimp subscriptions",
+  "engines": {
+    "node": ">= 6.9.0"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,6 +117,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.2.tgz#a5ccec6abb6060d5f20d256fb03ed743e9774999"
   integrity sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ==
 
+"@types/node@^6.9.0":
+  version "6.14.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.14.9.tgz#733583e21ef0eab85a9737dfafbaa66345a92ef0"
+  integrity sha512-leP/gxHunuazPdZaCvsCefPQxinqUDsCxCR5xaDUrY2MkYxQRFZZwU5e7GojyYsGB7QVtCi7iVEl/hoFXQYc+w==
+
 "@types/superagent@^4.1.3":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-4.1.3.tgz#52566ddd8957273b477c3e187c930fd791a95b2e"
@@ -395,11 +400,6 @@ crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
-
-crypto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
-  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
 
 debug@3.2.6:
   version "3.2.6"


### PR DESCRIPTION
* Avoid warning during install in dependent projects
* Add @types/node
* Explicitly state required Node.js version to 6.9.0 (which is an LTS)

Fixes #2 